### PR TITLE
AzureKeyCredential should be ApiKeyCredential for the latest OpenAI SDK

### DIFF
--- a/Workshops/PodcastCopilotPowerApp/Lab2/README.md
+++ b/Workshops/PodcastCopilotPowerApp/Lab2/README.md
@@ -95,7 +95,7 @@ For this lab, make sure you have the following ready:
 1. In the terminal window, run the following command to install the prerelease version of the Azure OpenAI SDK:
 
     ```bash
-    dotnet add package Azure.AI.OpenAI --version 2.0.0-beta.5
+    dotnet add package Azure.AI.OpenAI --version 2.0.0
     ```
 
 1. Then run the following command to install the Newtonsoft.Json package:
@@ -135,7 +135,7 @@ For this lab, make sure you have the following ready:
     //Instantiate OpenAI Client
     static AzureOpenAIClient azureOpenAIClient = new AzureOpenAIClient(
         new Uri(endpointSC),
-        new AzureKeyCredential(keySC));
+        new ApiKeyCredential(keySC));
     ```
 
 1. Then below the above code, add the following code to perform **Audio Transcription**:
@@ -144,7 +144,7 @@ For this lab, make sure you have the following ready:
     //Get Audio Transcription
     public static async Task<string> GetTranscription(string podcastUrl)
     {
-        var decodededUrl = HttpUtility.UrlDecode(podcastUrl);
+        var decodedUrl = HttpUtility.UrlDecode(podcastUrl);
 
         HttpClient httpClient = new HttpClient();
         Stream audioStreamFromBlob = await httpClient.GetStreamAsync(decodededUrl);


### PR DESCRIPTION
I might find a breaking change in the latest OpenAI SDK v2.0. We cannot use `AzureKeyCredential` in the constructor but we need to use `ApiKeyCredential` instead.